### PR TITLE
feature: Quarkus native + performance improvements + grouping

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -24,19 +24,20 @@ env:
 
 jobs:
   minikube:
-    name: Integration Tests in Minikube Cluster
+    name: K8S
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        minikube: [v1.5.1]
         kubernetes: [v1.16.2,v1.17.2]
+        suite: ['quarkus','springboot','other']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2.0.0
       - name: Setup Minikube-Kubernetes
         uses: manusa/actions-setup-minikube@v1.0.0
         with:
-          minikube version: ${{ matrix.minikube }}
+          minikube version: v1.5.1
           kubernetes version: ${{ matrix.kubernetes }}
       - name: Setup Java 11
         uses: actions/setup-java@v1
@@ -54,16 +55,18 @@ jobs:
           cd $JKUBE_DIR \
           && JKUBE_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec) \
           && cd .. \
-          && ./mvnw -B -PKubernetes clean verify -Djkube.version="$JKUBE_VERSION"
+          && ./mvnw -B -PKubernetes,${{ matrix.suite }} clean verify -Djkube.version="$JKUBE_VERSION"
   openshift:
-    name: Integration Tests in OpenShift Cluster
+    name: OpenShift
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         openshift: [v3.9.0,v3.11.0]
+        suite: ['quarkus','springboot','other']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2.0.0
       - name: Setup OpenShift
         uses: manusa/actions-setup-openshift@v1.0.1
         with:
@@ -84,4 +87,4 @@ jobs:
           cd $JKUBE_DIR \
           && JKUBE_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec) \
           && cd .. \
-          && ./mvnw -B -POpenShift clean verify -Djkube.version="$JKUBE_VERSION" -Djunit.jupiter.execution.parallel.config.fixed.parallelism=2
+          && ./mvnw -B -POpenShift,${{ matrix.suite }} clean verify -Djkube.version="$JKUBE_VERSION" -Djunit.jupiter.execution.parallel.config.fixed.parallelism=2

--- a/README.md
+++ b/README.md
@@ -2,4 +2,29 @@
 
 This project hosts Integration test suites for https://github.com/eclipse/jkube.
 
+## Test Structure
+
+In order to be able to run the tests in a CI environment without hogging the resources
+and to provide specific tests for OpenShift clusters, test suites are divided in the following
+way.
+
+### Tags
+
+There are two tags which match with a maven profile (`Kubernetes` & `OpenShift`).
+
+Each of these tags should be applied to a specific test case suite in order to execute
+the given tests only when that profile is specified.
+
+e.g. when running with a standard k8s cluster `mvn verify -PKubernetes`
+
+### Suite groups
+
+Tests are divided into several groups in order to run only a set of tests.
+
+As of now, test groups are: `quarkus`, `springboot`, `other`
+
+Following the same principle as with tags, in order to activate a given set of tests,
+a profile matching the group name defined above must be specified-
+
+e.g. Spring Boot tests when running in an Open Shift cluster `mvn verify -POpenShift,springboot`
 

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -77,7 +77,7 @@
           </execution>
         </executions>
         <configuration>
-          <systemProperties>
+          <systemProperties combine.children="append">
             <property>
               <name>jkubeVersion</name>
               <value>${jkube.version}</value>

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/Locks.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/Locks.java
@@ -15,7 +15,7 @@ package org.eclipse.jkube.integrationtests;
 
 public class Locks {
 
-  public static final String CLUSTER_APPLY = "cluster.apply";
+  public static final String CLUSTER_RESOURCE_INTENSIVE = "cluster.resource.intensive.operation";
   public static final String SPRINGBOOT_COMPLETE_K8s = "springboot.complete.k8s";
 
   private Locks() {

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/OpenShift.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/OpenShift.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.integrationtests;
+
+import io.fabric8.openshift.client.OpenShiftClient;
+
+public class OpenShift {
+
+  private static final String S2I_BUILD_SUFFIX = "-s2i";
+  private static final String OPENSHIFT_BUILD_LABEL = "openshift.io/build.name";
+
+  private OpenShift() {}
+
+  public static void cleanUpCluster(OpenShiftClient oc, JKubeCase jKubeCase) {
+    oc.imageStreams().withName(jKubeCase.getApplication()).delete();
+    oc.builds().withLabel("buildconfig", jKubeCase.getApplication()+S2I_BUILD_SUFFIX).delete();
+    oc.buildConfigs().withName(jKubeCase.getApplication()+S2I_BUILD_SUFFIX).delete();
+    oc.pods().withLabel(OPENSHIFT_BUILD_LABEL).list().getItems().stream()
+      .filter(p -> p.getMetadata().getLabels().get(OPENSHIFT_BUILD_LABEL).startsWith(jKubeCase.getApplication()+S2I_BUILD_SUFFIX))
+      .forEach(p -> oc.resource(p).delete());
+  }
+}

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/maven/BaseMavenCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/maven/BaseMavenCase.java
@@ -20,6 +20,7 @@ import org.eclipse.jkube.integrationtests.JKubeCase;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -35,7 +36,7 @@ import static org.hamcrest.Matchers.notNullValue;
 public abstract class BaseMavenCase implements MavenProject {
 
   protected List<String> getProfiles() {
-    return Collections.emptyList();
+    return new ArrayList<>();
   }
 
   protected static void assertThatShouldDeleteAllAppliedResources(JKubeCase jKubeCase) {

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/quarkus/rest/Quarkus.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/quarkus/rest/Quarkus.java
@@ -14,7 +14,6 @@
 package org.eclipse.jkube.integrationtests.quarkus.rest;
 
 import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import org.eclipse.jkube.integrationtests.JKubeCase;
 import org.eclipse.jkube.integrationtests.maven.BaseMavenCase;
 
@@ -26,11 +25,11 @@ import static org.hamcrest.Matchers.hasSize;
 
 abstract class Quarkus extends BaseMavenCase implements JKubeCase {
 
-  static final String PROJECT_QUARKUS = "projects-to-be-tested/quarkus/rest";
+  static final String PROJECT_QUARKUS_REST = "projects-to-be-tested/quarkus/rest";
 
   @Override
   public String getProject() {
-    return PROJECT_QUARKUS;
+    return PROJECT_QUARKUS_REST;
   }
 
   @Override
@@ -40,7 +39,7 @@ abstract class Quarkus extends BaseMavenCase implements JKubeCase {
 
   final Pod assertThatShouldApplyResources() throws Exception {
     final Pod pod = awaitPod(this).getKubernetesResource();
-    assertPod(pod).apply(this).logContains("quarkus-rest 0.0.0-SNAPSHOT (running on Quarkus 1.2.0.Final) started in", 60);
+    assertPod(pod).apply(this).logContains("quarkus-rest 0.0.0-SNAPSHOT (running on Quarkus 1.2.1.Final) started in", 60);
     awaitService(this, pod.getMetadata().getNamespace())
       .assertIsNodePort()
       .assertExposed()
@@ -50,6 +49,5 @@ abstract class Quarkus extends BaseMavenCase implements JKubeCase {
         equalTo("{\"applicationName\":\"JKube\",\"message\":\"Subatomic JKube really whips the llama's ass!\"}"));
     return pod;
   }
-
 
 }

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/quarkus/rest/QuarkusK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/quarkus/rest/QuarkusK8sITCase.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 
 import java.io.File;
 
-import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_APPLY;
+import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_RESOURCE_INTENSIVE;
 import static org.eclipse.jkube.integrationtests.Tags.KUBERNETES;
 import static org.eclipse.jkube.integrationtests.assertions.DeploymentAssertion.assertDeploymentExists;
 import static org.eclipse.jkube.integrationtests.assertions.DeploymentAssertion.awaitDeployment;
@@ -85,7 +85,7 @@ class QuarkusK8sITCase extends Quarkus {
     // Then
     assertThat(invocationResult.getExitCode(), Matchers.equalTo(0));
     final File metaInfDirectory = new File(
-      String.format("../%s/target/classes/META-INF", PROJECT_QUARKUS));
+      String.format("../%s/target/classes/META-INF", PROJECT_QUARKUS_REST));
     assertThat(metaInfDirectory.exists(), equalTo(true));
     assertThat(new File(metaInfDirectory, "jkube/kubernetes.yml"). exists(), equalTo(true));
     assertThat(new File(metaInfDirectory, "jkube/kubernetes/quarkus-rest-deployment.yml"). exists(), equalTo(true));
@@ -95,7 +95,7 @@ class QuarkusK8sITCase extends Quarkus {
   @Test
   @Order(3)
   @DisplayName("k8s:apply, should deploy pod and service")
-  @ResourceLock(value = CLUSTER_APPLY, mode = READ_WRITE)
+  @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @SuppressWarnings("unchecked")
   void k8sApply() throws Exception {
     // When

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/quarkus/rest/QuarkusOcITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/quarkus/rest/QuarkusOcITCase.java
@@ -32,7 +32,8 @@ import java.io.File;
 import java.util.Properties;
 
 import static org.eclipse.jkube.integrationtests.Hacks.hackToPreventNullPointerInRegistryServiceCreateAuthConfig;
-import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_APPLY;
+import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_RESOURCE_INTENSIVE;
+import static org.eclipse.jkube.integrationtests.OpenShift.cleanUpCluster;
 import static org.eclipse.jkube.integrationtests.Tags.OPEN_SHIFT;
 import static org.eclipse.jkube.integrationtests.assertions.DockerAssertion.assertImageWasRecentlyBuilt;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -63,8 +64,10 @@ class QuarkusOcITCase extends Quarkus {
 
   @Test
   @Order(1)
+  @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("oc:build, in docker mode, should create image")
   void ocBuild() throws Exception {
+    oc.imageStreams().delete();
     // Given
     hackToPreventNullPointerInRegistryServiceCreateAuthConfig("openjdk:11");
     final Properties properties = new Properties();
@@ -88,7 +91,7 @@ class QuarkusOcITCase extends Quarkus {
     // Then
     assertThat(invocationResult.getExitCode(), Matchers.equalTo(0));
     final File metaInfDirectory = new File(
-      String.format("../%s/target/classes/META-INF", PROJECT_QUARKUS));
+      String.format("../%s/target/classes/META-INF", PROJECT_QUARKUS_REST));
     assertThat(metaInfDirectory.exists(), equalTo(true));
     assertThat(new File(metaInfDirectory, "jkube/openshift.yml"). exists(), equalTo(true));
     assertThat(new File(metaInfDirectory, "jkube/openshift/quarkus-rest-deploymentconfig.yml"). exists(), equalTo(true));
@@ -98,7 +101,7 @@ class QuarkusOcITCase extends Quarkus {
 
   @Test
   @Order(3)
-  @ResourceLock(value = CLUSTER_APPLY, mode = READ_WRITE)
+  @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("oc:apply, should deploy pod and service")
   void ocApply() throws Exception {
     // When
@@ -117,5 +120,6 @@ class QuarkusOcITCase extends Quarkus {
     // Then
     assertThat(invocationResult.getExitCode(), Matchers.equalTo(0));
     assertThatShouldDeleteAllAppliedResources(this);
+    cleanUpCluster(oc, this);
   }
 }

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/complete/CompleteDockerITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/complete/CompleteDockerITCase.java
@@ -33,7 +33,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
-import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_APPLY;
+import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_RESOURCE_INTENSIVE;
 import static org.eclipse.jkube.integrationtests.Locks.SPRINGBOOT_COMPLETE_K8s;
 import static org.eclipse.jkube.integrationtests.Tags.KUBERNETES;
 import static org.eclipse.jkube.integrationtests.assertions.DeploymentAssertion.assertDeploymentExists;
@@ -133,7 +133,7 @@ class CompleteDockerITCase extends Complete {
 
   @Test
   @Order(3)
-  @ResourceLock(value = CLUSTER_APPLY, mode = READ_WRITE)
+  @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("k8s:apply, should deploy pod and service form manifests in specific directory")
   void k8sApply() throws Exception {
     // Given

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/complete/CompleteK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/complete/CompleteK8sITCase.java
@@ -13,7 +13,6 @@
  */
 package org.eclipse.jkube.integrationtests.springboot.complete;
 
-import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.apache.maven.shared.invoker.InvocationResult;
@@ -32,7 +31,7 @@ import java.io.File;
 import java.util.Collections;
 import java.util.List;
 
-import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_APPLY;
+import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_RESOURCE_INTENSIVE;
 import static org.eclipse.jkube.integrationtests.Locks.SPRINGBOOT_COMPLETE_K8s;
 import static org.eclipse.jkube.integrationtests.Tags.KUBERNETES;
 import static org.eclipse.jkube.integrationtests.assertions.DeploymentAssertion.assertDeploymentExists;
@@ -105,7 +104,7 @@ class CompleteK8sITCase extends Complete {
 
   @Test
   @Order(3)
-  @ResourceLock(value = CLUSTER_APPLY, mode = READ_WRITE)
+  @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("k8s:apply, should deploy pod and service")
   @SuppressWarnings("unchecked")
   void k8sApply() throws Exception {

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/thorntail/ThorntailK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/thorntail/ThorntailK8sITCase.java
@@ -32,7 +32,7 @@ import java.io.File;
 import java.util.Collections;
 import java.util.List;
 
-import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_APPLY;
+import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_RESOURCE_INTENSIVE;
 import static org.eclipse.jkube.integrationtests.Tags.KUBERNETES;
 import static org.eclipse.jkube.integrationtests.assertions.DeploymentAssertion.assertDeploymentExists;
 import static org.eclipse.jkube.integrationtests.assertions.DeploymentAssertion.awaitDeployment;
@@ -101,7 +101,7 @@ class ThorntailK8sITCase extends Thorntail {
 
   @Test
   @Order(3)
-  @ResourceLock(value = CLUSTER_APPLY, mode = READ_WRITE)
+  @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("k8s:apply, should deploy pod and service")
   @SuppressWarnings("unchecked")
   void k8sApply() throws Exception {

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/thorntail/ThorntailOcITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/thorntail/ThorntailOcITCase.java
@@ -33,7 +33,8 @@ import java.io.File;
 import java.util.Collections;
 import java.util.List;
 
-import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_APPLY;
+import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_RESOURCE_INTENSIVE;
+import static org.eclipse.jkube.integrationtests.OpenShift.cleanUpCluster;
 import static org.eclipse.jkube.integrationtests.Tags.OPEN_SHIFT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -69,6 +70,7 @@ class ThorntailOcITCase extends Thorntail {
 
   @Test
   @Order(1)
+  @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("oc:build, should create image")
   void ocBuild() throws Exception {
     // When
@@ -99,7 +101,7 @@ class ThorntailOcITCase extends Thorntail {
 
   @Test
   @Order(3)
-  @ResourceLock(value = CLUSTER_APPLY, mode = READ_WRITE)
+  @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("oc:apply, should deploy pod and service")
   void ocApply() throws Exception {
     // When
@@ -118,5 +120,6 @@ class ThorntailOcITCase extends Thorntail {
     // Then
     assertThat(invocationResult.getExitCode(), Matchers.equalTo(0));
     assertThatShouldDeleteAllAppliedResources(this);
+    cleanUpCluster(oc, this);
   }
 }

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/vertx/VertxK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/vertx/VertxK8sITCase.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 
 import java.io.File;
 
-import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_APPLY;
+import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_RESOURCE_INTENSIVE;
 import static org.eclipse.jkube.integrationtests.Tags.KUBERNETES;
 import static org.eclipse.jkube.integrationtests.assertions.DeploymentAssertion.assertDeploymentExists;
 import static org.eclipse.jkube.integrationtests.assertions.DeploymentAssertion.awaitDeployment;
@@ -94,7 +94,7 @@ class VertxK8sITCase extends Vertx {
 
   @Test
   @Order(3)
-  @ResourceLock(value = CLUSTER_APPLY, mode = READ_WRITE)
+  @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("k8s:apply, should deploy pod and service")
   @SuppressWarnings("unchecked")
   void k8sApply() throws Exception {

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/vertx/VertxOcITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/vertx/VertxOcITCase.java
@@ -31,7 +31,8 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 
 import java.io.File;
 
-import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_APPLY;
+import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_RESOURCE_INTENSIVE;
+import static org.eclipse.jkube.integrationtests.OpenShift.cleanUpCluster;
 import static org.eclipse.jkube.integrationtests.Tags.OPEN_SHIFT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -62,6 +63,7 @@ class VertxOcITCase extends Vertx {
 
   @Test
   @Order(1)
+  @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("oc:build, should create image")
   void ocBuild() throws Exception {
     // When
@@ -92,7 +94,7 @@ class VertxOcITCase extends Vertx {
 
   @Test
   @Order(3)
-  @ResourceLock(value = CLUSTER_APPLY, mode = READ_WRITE)
+  @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("oc:apply, should deploy pod and service")
   void ocApply() throws Exception {
     // When
@@ -111,5 +113,6 @@ class VertxOcITCase extends Vertx {
     // Then
     assertThat(invocationResult.getExitCode(), Matchers.equalTo(0));
     assertThatShouldDeleteAllAppliedResources(this);
+    cleanUpCluster(oc, this);
   }
 }

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/zeroconfig/ZeroConfigK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/zeroconfig/ZeroConfigK8sITCase.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 
 import java.io.File;
 
-import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_APPLY;
+import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_RESOURCE_INTENSIVE;
 import static org.eclipse.jkube.integrationtests.Tags.KUBERNETES;
 import static org.eclipse.jkube.integrationtests.assertions.DeploymentAssertion.assertDeploymentExists;
 import static org.eclipse.jkube.integrationtests.assertions.DeploymentAssertion.awaitDeployment;
@@ -94,7 +94,7 @@ class ZeroConfigK8sITCase extends ZeroConfig {
 
   @Test
   @Order(3)
-  @ResourceLock(value = CLUSTER_APPLY, mode = READ_WRITE)
+  @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("k8s:apply, should deploy pod and service")
   @SuppressWarnings("unchecked")
   void k8sApply() throws Exception {

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/zeroconfig/ZeroConfigOcITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/zeroconfig/ZeroConfigOcITCase.java
@@ -32,7 +32,8 @@ import java.io.File;
 import java.util.Properties;
 
 import static org.eclipse.jkube.integrationtests.Hacks.hackToPreventNullPointerInRegistryServiceCreateAuthConfig;
-import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_APPLY;
+import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_RESOURCE_INTENSIVE;
+import static org.eclipse.jkube.integrationtests.OpenShift.cleanUpCluster;
 import static org.eclipse.jkube.integrationtests.Tags.OPEN_SHIFT;
 import static org.eclipse.jkube.integrationtests.assertions.DockerAssertion.assertImageWasRecentlyBuilt;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -98,7 +99,7 @@ class ZeroConfigOcITCase extends ZeroConfig {
 
   @Test
   @Order(3)
-  @ResourceLock(value = CLUSTER_APPLY, mode = READ_WRITE)
+  @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("oc:apply, should deploy pod and service")
   void ocApply() throws Exception {
     // When
@@ -117,6 +118,7 @@ class ZeroConfigOcITCase extends ZeroConfig {
     // Then
     assertThat(invocationResult.getExitCode(), Matchers.equalTo(0));
     assertThatShouldDeleteAllAppliedResources(this);
+    cleanUpCluster(oc, this);
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -40,23 +40,12 @@
     <junit.version>5.5.1</junit.version>
     <license-maven-plugin.version>3.0</license-maven-plugin.version>
     <hamcrest.version>2.0.0.0</hamcrest.version>
-    <quarkus.version>1.2.0.Final</quarkus.version>
+    <quarkus.version>1.2.1.Final</quarkus.version>
     <spring-boot.version>2.2.0.RELEASE</spring-boot.version>
     <thorntail.version>2.5.0.Final</thorntail.version>
     <vertx.version>3.8.5</vertx.version>
     <vertx.plugin.version>1.0.22</vertx.plugin.version>
   </properties>
-
-  <modules>
-    <module>projects-to-be-tested/quarkus/rest</module>
-    <module>projects-to-be-tested/spring-boot/complete</module>
-    <module>projects-to-be-tested/spring-boot/multi-profile</module>
-    <module>projects-to-be-tested/spring-boot/zero-config</module>
-    <module>projects-to-be-tested/thorntail/microprofile</module>
-    <module>projects-to-be-tested/vertx/simplest</module>
-    <module>projects-to-be-tested/webapp/zero-config</module>
-    <module>it</module>
-  </modules>
 
   <repositories>
     <repository>
@@ -241,4 +230,101 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>quarkus</id>
+      <modules>
+        <module>projects-to-be-tested/quarkus/native</module>
+        <module>projects-to-be-tested/quarkus/rest</module>
+      </modules>
+      <activation>
+        <file>
+          <exists>
+            projects-to-be-tested/quarkus/native/target
+          </exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/integrationtests/quarkus/**/*ITCase.java</include>
+              </includes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>springboot</id>
+      <modules>
+        <module>projects-to-be-tested/spring-boot/complete</module>
+        <module>projects-to-be-tested/spring-boot/multi-profile</module>
+        <module>projects-to-be-tested/spring-boot/zero-config</module>
+      </modules>
+      <activation>
+        <file>
+          <exists>
+            projects-to-be-tested/spring-boot/complete/target
+          </exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/integrationtests/springboot/**/*ITCase.java</include>
+              </includes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>other</id>
+      <modules>
+        <module>projects-to-be-tested/thorntail/microprofile</module>
+        <module>projects-to-be-tested/vertx/simplest</module>
+        <module>projects-to-be-tested/webapp/zero-config</module>
+      </modules>
+      <activation>
+        <file>
+          <exists>
+            projects-to-be-tested/thorntail/microprofile/target
+          </exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/integrationtests/thorntail/**/*ITCase.java</include>
+                <include>**/integrationtests/vertx/**/*ITCase.java</include>
+                <include>**/integrationtests/webapp/**/*ITCase.java</include>
+              </includes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!-- Add IT module in a profile so that it gets imported the last and the projects get built first (before tests run) -->
+      <id>it-last-module-always-active-hack</id>
+      <activation>
+        <file><exists>.</exists></file> <!-- Hack to activate by default always (activeByDefault gets overridden :( ) -->
+      </activation>
+      <modules>
+        <module>it</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>

--- a/projects-to-be-tested/quarkus/native/pom.xml
+++ b/projects-to-be-tested/quarkus/native/pom.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Red Hat, Inc.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at:
+
+        https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.jkube.integration-tests</groupId>
+    <artifactId>jkube-integration-tests-project</artifactId>
+    <version>${revision}</version>
+    <relativePath>../../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>quarkus-native</artifactId>
+  <name>${global.name} :: Quarkus :: GraalVM Native</name>
+  <description>
+    Quarkus GraalVM Native project
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.smallrye</groupId>
+          <artifactId>smallrye-config</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-jackson</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <version>${quarkus.version}</version>
+        <executions>
+          <execution>
+            <id>package</id>
+            <phase>package</phase>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>native-image</id>
+            <goals>
+              <goal>native-image</goal>
+            </goals>
+            <configuration>
+              <enableHttpUrlHandler>true</enableHttpUrlHandler>
+              <dockerBuild>true</dockerBuild>
+              <additionalBuildArgs>
+                <additionalBuildArg>--allow-incomplete-classpath</additionalBuildArg>
+                <additionalBuildArg>-H:IncludeResources=.*\.json$</additionalBuildArg>
+              </additionalBuildArgs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.jkube</groupId>
+        <artifactId>k8s-maven-plugin</artifactId>
+        <configuration>
+          <enricher>
+            <config>
+              <jkube-service>
+                <type>NodePort</type>
+              </jkube-service>
+            </config>
+          </enricher>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.jkube</groupId>
+        <artifactId>oc-maven-plugin</artifactId>
+        <configuration>
+            <enricher>
+              <config>
+                <jkube-service>
+                  <type>NodePort</type>
+                </jkube-service>
+              </config>
+            </enricher>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>native</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <jkube.generator.name>integration-tests/quarkus-native-is-amazing</jkube.generator.name>
+        <jkube.generator.quarkus.nativeImage>true</jkube.generator.quarkus.nativeImage>
+      </properties>
+    </profile>
+  </profiles>
+</project>

--- a/projects-to-be-tested/quarkus/native/src/main/java/org/eclipse/jkube/integrationtests/quarkus/na7ive/NativeResource.java
+++ b/projects-to-be-tested/quarkus/native/src/main/java/org/eclipse/jkube/integrationtests/quarkus/na7ive/NativeResource.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.integrationtests.quarkus.na7ive;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/")
+public class NativeResource {
+
+  private NativeService nativeService;
+
+  @GET
+  @Produces(MediaType.TEXT_PLAIN)
+  public Response get() {
+      return Response.ok(nativeService.getNativeResource()).build();
+    }
+
+  @Inject
+  public void setNativeService(NativeService nativeService) {
+    this.nativeService = nativeService;
+  }
+}

--- a/projects-to-be-tested/quarkus/native/src/main/java/org/eclipse/jkube/integrationtests/quarkus/na7ive/NativeService.java
+++ b/projects-to-be-tested/quarkus/native/src/main/java/org/eclipse/jkube/integrationtests/quarkus/na7ive/NativeService.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.integrationtests.quarkus.na7ive;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.io.InputStream;
+
+@Singleton
+public class NativeService {
+
+  private static final Logger log = LoggerFactory.getLogger(NativeService.class);
+
+  private static final String NATIVE_RESOURCE= "/native.json";
+
+  private String nativeResource;
+
+  @PostConstruct
+  protected final void initialize() {
+    final ObjectMapper objectMapper = new ObjectMapper();
+    try (final InputStream nativeStream = NativeService.class.getResourceAsStream(NATIVE_RESOURCE)) {
+      nativeResource = objectMapper.readValue(nativeStream, String.class);
+    } catch (IOException ex) {
+      log.error("Error loading native.json", ex);
+    }
+  }
+
+  String getNativeResource() {
+    return nativeResource;
+  }
+}

--- a/projects-to-be-tested/quarkus/native/src/main/resources/native.json
+++ b/projects-to-be-tested/quarkus/native/src/main/resources/native.json
@@ -1,0 +1,1 @@
+"JKube with awesome native subatomic superpowers"


### PR DESCRIPTION
Tests are now separated into different group in order to avoid hogging all woker's resources.

Once this one is merged, workflows in eclipse/jkube should be updated accordingly. I'll open a PR there too.